### PR TITLE
Pricing logic improvement

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
         <option value="25">11-25</option>
         <option value="50">26-50</option>
         <option value="100">51-100</option>
-        <option value="200">>100</option>
+        <option value="200">&gt;100</option>
       </select>
       contributing developers.
       </p>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
       <p>
       I have 
       <select id="repos">
-        <option value="25">0-10</option>
+        <option value="0">0</option>
+        <option value="25">1-10</option>
         <option value="50">11-20</option>
         <option value="100">21-50</option>
         <option value="200">51-125</option>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 
     <div id="cost-compare">
       <p>
-      I have 
+      I am an <strong>organization</strong> with
       <select id="repos">
         <option value="0">0</option>
         <option value="25">1-10</option>
@@ -42,6 +42,10 @@
       </select>
       contributing developers.
       </p>
+      <p><small>For individuals, Github has a
+        <a href="https://github.com/pricing"
+           title="The pricing guide on Github"
+           target="_blank">different pricing structure</a>.</small></p>
       <div id="results" class="cf">
         <div id="winner"></div>
         <div class="one-result">


### PR DESCRIPTION
This set of commits clarifies two tidbits about Github's pricing policy:
- Organizations with no private repositories don't pay anything.
- Github has a separate pricing policy for individuals, which is cheaper than the organizational policy.

This should make the comparison between the two more fair.
